### PR TITLE
0308 한윤석 3문제

### DIFF
--- a/한윤석/0308/B1245.java
+++ b/한윤석/0308/B1245.java
@@ -1,0 +1,82 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+//백준 1245 산봉우리 골드5
+public class B1245 {
+
+	static int R,C; //행, 열
+	static int m [][]; //맵 정보
+	static boolean visit[][]; //탐색 시작 후 방문했는지 여부
+	static boolean check[][]; //산 봉우리 체크 여부
+	static int ans = 0;
+	static int d[][] = {{1,0},{-1,0},{0,1},{0,-1},{1,-1},{-1,1},{1,1},{-1,-1}};
+	
+	public static void main(String[] args) throws IOException {
+		//변수초기화
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		R = Integer.parseInt(st.nextToken());
+		C = Integer.parseInt(st.nextToken());
+		m = new int[R][C];
+		check = new boolean[R][C];
+		
+		//맵 정보 입력
+		for(int i=0; i<R; i++) {
+			st = new StringTokenizer(br.readLine(), " ");
+			for(int j=0; j<C; j++) m[i][j] = Integer.parseInt(st.nextToken());
+		}
+		
+		//이미 산 봉우리로 이어져있어서 탐색했던 칸이 아닐 때 bfs 탐색 시작
+		for(int i=0; i<R; i++) {
+			for(int j=0; j<C; j++) if(!check[i][j]) bfs(i,j);
+		}
+		
+		System.out.println(ans);
+	}
+	
+	static void bfs(int r, int c) {
+		visit = new boolean[R][C];
+		visit[r][c] = true; //이번 탐색에서 방문 체크
+		check[r][c] = true; //산 봉우리 체크
+		Queue<Pos> q = new LinkedList<>();
+		q.add(new Pos(r,c));
+		boolean flag = true;
+		
+		while(!q.isEmpty()) {
+			Pos current = q.poll();
+			
+			for(int i=0; i<8; i++) { //8방 탐색
+				int nr = current.r + d[i][0];
+				int nc = current.c + d[i][1];
+				
+				if(nr < 0 || nc < 0 || nr >= R || nc >= C || visit[nr][nc]) continue;
+				
+				//같은 높이라면 같은 산봉우리이므로 산봉우리 체크 후 해당 칸도 탐색위해 큐에 담음 
+				if(m[nr][nc] == m[current.r][current.c]) {
+					visit[nr][nc] = true;
+					check[nr][nc] = true;
+					q.add(new Pos(nr,nc));
+				}else if(m[nr][nc] > m[current.r][current.c]) { //자신보다 큰 높이 존재하면 산봉우리 안되므로 종료
+					flag=false;
+					break;
+				}
+			}
+		}
+		
+		if(flag) ans++;
+	}
+	
+	static class Pos{
+		int r,c;
+		public Pos(int r, int c) {
+			this.r = r;
+			this.c = c;
+		}
+	}
+}

--- a/한윤석/0308/B16918.java
+++ b/한윤석/0308/B16918.java
@@ -1,0 +1,87 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+//백준 16918 봄버맨 실버1
+public class B16918 {
+	
+	static int R,C,N; //행, 열, N초 후
+	static int m [][];
+	static int d [][] = {{1,0},{0,1},{-1,0},{0,-1}};
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		R = Integer.parseInt(st.nextToken());
+		C = Integer.parseInt(st.nextToken());
+		N = Integer.parseInt(st.nextToken());
+		m = new int[R][C];
+		int now = 0;
+		
+		for(int i=0; i<R; i++) {
+			String input = br.readLine();
+			for(int j=0; j<C; j++) m[i][j] = input.charAt(j) == '.' ? 0 : 1;
+		}
+		
+		while(now++ != N) {
+			if(now == 1) continue;
+			setBombTime();
+			if(now%2 == 0) setNewBomb();
+			else if(now%2 == 1) explosion();
+		}
+		
+		for(int i=0; i<R; i++) {
+			for(int j=0; j<C; j++) {
+				if(m[i][j]>=1)System.out.print('O');
+				else System.out.print('.');
+			}
+			System.out.println();
+		}
+	}
+	
+	static void setBombTime() {
+		for(int i=0; i<R; i++) {
+			for(int j=0; j<C; j++) if(m[i][j] >= 1) m[i][j]++;
+		}
+	}
+	
+	static void setNewBomb() {
+		for(int i=0; i<R; i++) {
+			for(int j=0; j<C; j++) if(m[i][j] == 0) m[i][j]++;
+		}
+	}
+	
+	static void explosion() {
+		Queue<Pos> q = new LinkedList<>();
+		for(int i=0; i<R; i++) {
+			for(int j=0; j<C; j++) {
+				if(m[i][j] >= 3) q.add(new Pos(i,j));
+			}
+		}
+		
+		while(!q.isEmpty()) {
+			Pos current = q.poll();
+			m[current.r][current.c] = 0;
+			for(int i=0; i<4; i++) {
+				int nr = current.r + d[i][0];
+				int nc = current.c + d[i][1];
+				
+				if(nr < 0 || nc < 0 || nr >= R || nc >= C || m[nr][nc] == 0) continue;
+				m[nr][nc] = 0;
+			}
+		}
+	}
+	
+	static class Pos{
+		int r,c;
+		public Pos(int r, int c) {
+			this.r = r;
+			this.c = c;
+		}
+	}
+}

--- a/한윤석/0308/B16918.java
+++ b/한윤석/0308/B16918.java
@@ -11,30 +11,33 @@ import java.util.StringTokenizer;
 public class B16918 {
 	
 	static int R,C,N; //행, 열, N초 후
-	static int m [][];
+	static int m [][]; //맵 정보 0:빈칸 1>= 폭탄
 	static int d [][] = {{1,0},{0,1},{-1,0},{0,-1}};
 
 	public static void main(String[] args) throws IOException {
+		//변수 초기화
 		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
 		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
 		R = Integer.parseInt(st.nextToken());
 		C = Integer.parseInt(st.nextToken());
 		N = Integer.parseInt(st.nextToken());
 		m = new int[R][C];
-		int now = 0;
+		int now = 0; //현재까지 소요 시간
 		
+		//맵 정보 입력
 		for(int i=0; i<R; i++) {
 			String input = br.readLine();
 			for(int j=0; j<C; j++) m[i][j] = input.charAt(j) == '.' ? 0 : 1;
 		}
 		
 		while(now++ != N) {
-			if(now == 1) continue;
-			setBombTime();
-			if(now%2 == 0) setNewBomb();
-			else if(now%2 == 1) explosion();
+			if(now == 1) continue; //첫 1초는 건너뜀
+			setBombTime(); //폭탄 타이머 증가
+			if(now%2 == 0) setNewBomb(); //빈칸에 폭탄 설치
+			else if(now%2 == 1) explosion(); //3초 지난 폭탄 폭발
 		}
 		
+		//결과 출력
 		for(int i=0; i<R; i++) {
 			for(int j=0; j<C; j++) {
 				if(m[i][j]>=1)System.out.print('O');
@@ -44,19 +47,19 @@ public class B16918 {
 		}
 	}
 	
-	static void setBombTime() {
+	static void setBombTime() { //폭탄 타이머 증가
 		for(int i=0; i<R; i++) {
 			for(int j=0; j<C; j++) if(m[i][j] >= 1) m[i][j]++;
 		}
 	}
 	
-	static void setNewBomb() {
+	static void setNewBomb() { //빈칸에 폭탄 설치
 		for(int i=0; i<R; i++) {
 			for(int j=0; j<C; j++) if(m[i][j] == 0) m[i][j]++;
 		}
 	}
 	
-	static void explosion() {
+	static void explosion() { //3초 지난 폭탄 폭발
 		Queue<Pos> q = new LinkedList<>();
 		for(int i=0; i<R; i++) {
 			for(int j=0; j<C; j++) {

--- a/한윤석/0308/B20364.java
+++ b/한윤석/0308/B20364.java
@@ -1,0 +1,29 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+//백준 20364 부동산 다툼 실버2
+public class B20364 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		int N = Integer.parseInt(st.nextToken()); // 땅의 개수
+		int Q = Integer.parseInt(st.nextToken()); //오리 수
+		boolean [] visit = new boolean[N+1]; //방문 여부
+		
+		for(int i=0; i<Q; i++) {
+			int want = Integer.parseInt(br.readLine()); //원하는 땅
+			int min = Integer.MAX_VALUE; //방문한 땅 중 최소 노드
+			
+			for(int j=want; j>=1; j/=2) if(visit[j]) min = j; //want부터 1까지의 경로 중 방문한 땅 있다면 최소 노드 갱신
+			
+			if(min == Integer.MAX_VALUE) { //방문한 땅 하나도 없었다면
+				System.out.println("0");
+				visit[want] = true;
+			}else System.out.println(min); //방문한 땅 있었으면
+		}
+	}
+}


### PR DESCRIPTION
# 훈수, 조언, 반박, 질타 뭐든 환영입니다

### 농장관리
같은 높이를 구성하는 영역의 8 방향을 탐색하여 자신보다 큰 높이가 존재하는지를 체크하는 문제였습니다. 이미 연결된 봉우리를 통해 체크가 되어있는데 중복해서 체크하는 경우를 방지하기 위해 `cheeck` 배열을 사용했고, bfs 탐색을 시작하고서 방문한 칸을 중복해서 방문하는 경우 방지를 위해 `visit` 배열을 사용했습니다. flag를 통해 주변에 자신보다 큰 봉우리가 있는지 여부를 체크했습니다. dfs와 bfs 모두로 접근해봤는데, 이 문제만큼은 bfs로 접근하는게 오히려 머리가 덜 아팠어요
### 봄버맨
시뮬레이션 문제라 문제에서 요구하는 것을 그대로 구현하는데에 집중했습니다. 게임이 시작된 2초 후부터 `빈칸에 폭탄 설치`와 `3초 지난 폭탄 폭발` 액션이 번갈아 수행되기 때문에 이를 `now%2`로 구분해주었습니다. 각 칸의 입력이 `char`형태로 들어오지만 폭탄이 설치된지 몇 초가 흘렀는지를 저장하기 위해 `int`형으로 변환하면 쉽게 해결 가능했던 것 같습니다
### 부동산 다툼
i번 노드의 부모 노드 번호가 `i/2` 이기 때문에 i에서부터 2배씩 감소시키며 탐색하고, 방문한 땅이었을 때 해당 노드 번호를 저장하는 식으로(어차피 큰 거에서 작은 순으로 가기 때문에) 구현했습니다. 트리 문제이긴한데 난이도가 쉬워서 for문 2개로도 솔브 가능했어요