### PR TITLE
0405 육다빈, 쉬운 계단 수 & 전깃줄

### DIFF
--- a/육다빈/0405/b10844.java
+++ b/육다빈/0405/b10844.java
@@ -1,0 +1,29 @@
+package silver;
+
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class S10844_easyStairNumber {
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int N = sc.nextInt();
+		
+		long[][] dp = new long[2][10];
+		Arrays.fill(dp[0], 1);
+		dp[0][0] = 0;
+		
+		int idx = 0;
+		for(int n=1; n<N; n++) {
+			int now = (idx+1)%2; 	// 이번에 채울 배열의 인덱스
+			for(int i=0; i<10; i++) {
+				dp[now][i] = (i-1>=0 ? dp[idx][i-1] : 0) + (i+1<10 ? dp[idx][i+1] : 0)%1000000000;
+			}
+			idx = now;
+		}
+		long result = 0;
+		for(int i=0; i<10; i++) result = (result + dp[idx][i])%1000000000;
+		System.out.println(result);
+	}
+
+}

--- a/육다빈/0405/b2565.java
+++ b/육다빈/0405/b2565.java
@@ -1,0 +1,38 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+public class G2565_wire {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		int[][] wire = new int[N][2];
+		int[] lis = new int[N];
+		
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j=0; j<2; j++) wire[i][j] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(wire, Comparator.comparingInt(o1->o1[0])); //제발이거외워라;
+		
+		lis[0] = wire[0][1];
+		int result = 0;
+		for(int i=1; i<N; i++) {	// i : 현재 B전기줄의 번호
+			for(int j=0; j<N; j++) { // j : 앞서 연결된 전기줄 수. lis[j] : 연결된 전기줄 중 가장 뒷번호(B)
+				if(wire[i][1]<lis[j] || lis[j]==0) {
+					lis[j] = wire[i][1];
+					result = Math.max(result, j);
+					break;
+				}
+			}
+		}
+		System.out.println(N-result-1);
+	}
+
+}


### PR DESCRIPTION
# 쉬운 계단 수
사용 알고리즘 : DP
숫자의 길이를 하나씩 늘려가면서, 각 회차마다 ~으로 끝나는 경우의 수를 저장했습니다 (0~9까지 총 10가지 종류)
2x10으로 이중배열을 선언해서, 이전dp값과 현재 dp값을 번갈아가며 저장했습니다.
다시 생각해보니 메모리용량 고려 안할거면 굳이 저렇게 저장 안하고 총 숫자 길이(N)만큼 배열을 선언(dp[N][10])해서 반복문 돌려도 됐을거 같아요..

# 전기줄
사용 알고리즘 : DP - LIS
LIS 심화버전처럼 배열을 만들어 풀었으나, 탐색과정에서 이분탐색을 사용하진 않았습니다.