### PR TITLE
0412 한윤석 연구소2, 게리맨더링

### DIFF
--- a/한윤석/0412/b171741_연구소2.java
+++ b/한윤석/0412/b171741_연구소2.java
@@ -1,0 +1,108 @@
+public class B17141_연구소2 {
+
+	static int N,M; //크기, 바이러스 놓을 수
+	static int m[][], res[][]; //맵 정보, 결과 맵 정보
+	static Pos select[]; //선택한 바이러스 위치
+	static int d [][] = {{1,0},{-1,0},{0,1},{0,-1}};
+	static int ans = Integer.MAX_VALUE;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		m = new int[N][N];
+		res = new int[N][N];
+		select = new Pos[M];
+		
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j<N; j++) m[i][j] = Integer.parseInt(st.nextToken());
+		}
+		
+		comb(0,0,0);
+		
+		if(ans == Integer.MAX_VALUE) System.out.println("-1");
+		else System.out.println(ans);
+	}
+	
+	static void comb(int sr, int sc, int cnt) {
+		if(cnt == M) {
+			initRes();
+			
+			for(int i=0; i<M; i++) bfs(select[i].r, select[i].c);
+			
+			int maxNum = getMaxNum();
+			if(maxNum>=0) ans = Math.min(ans, maxNum);
+			
+			return;
+		}
+		
+		for(int i=sr; i<N; i++) {
+			for(int j=(i==sr?sc:0); j<N; j++) {
+				if(m[i][j] < 2) continue;
+				
+				select[cnt] = new Pos(i,j);
+				if(j==N-1) comb(i+1, 0, cnt+1);
+				else comb(i, j+1, cnt+1);
+			}
+		}
+	}
+	
+	static void bfs(int r, int c) {
+		Queue<Pos> q = new LinkedList<>();
+		q.add(new Pos(r,c));
+		int time = 0;
+		
+		while(!q.isEmpty()) {
+			int size = q.size();
+			time++;
+			
+			for(int t=0; t<size; t++) {
+				Pos p = q.poll();
+				
+				for(int i=0; i<4; i++) {
+					int nr = p.r + d[i][0];
+					int nc = p.c + d[i][1];
+					
+					//범위 유효성 검사 + 다음 칸이 벽이거나, 바이러스 놓을 위치거나, 더 빨리 도달한 적 있으면 넘김
+					if(nr < 0 || nc < 0 || nr >= N || nc >= N || res[nr][nc] == -2 || res[nr][nc] == 0 || (res[nr][nc] > 0 && res[nr][nc] <= time)) continue;
+					
+					res[nr][nc] = time;
+					q.add(new Pos(nr,nc));
+				}
+			}
+		}
+	}
+	
+	//res배열을 벽은 -2, 빈 칸은 -1, 바이러스 위치는 0으로 초기화
+	static void initRes() {
+		for(int i=0; i<N; i++) {
+			for(int j=0; j<N; j++) {
+				if(m[i][j] == 1) res[i][j] = -2; //벽 설치
+				else res[i][j] = -1;
+			}
+		}
+		for(int i=0; i<M; i++) res[select[i].r][select[i].c] = 0;
+	}
+	
+	//res배열에서 아직 빈칸이 있으면 -1리턴, 빈칸 없으면 가장 큰 소요시간 리턴
+	static int getMaxNum() {
+		int max = 0;
+		for(int i=0; i<N; i++) {
+			for(int j=0; j<N; j++) {
+				if(res[i][j] == -1) return -1;
+				max = Math.max(max, res[i][j]);
+			}
+		}
+		return max;
+	}
+	
+	static class Pos{
+		int r, c;
+		public Pos(int r, int c) {
+			this.r = r;
+			this.c = c;
+		}
+	}
+}

--- a/한윤석/0412/b17471_게리맨더링.java
+++ b/한윤석/0412/b17471_게리맨더링.java
@@ -1,0 +1,88 @@
+public class B17471_게리맨더링 {
+
+	static int N;
+	static int pop[]; //i구역의 인구수
+	static boolean m[][]; //연결관계
+	static boolean select[]; //뽑은 선거구
+	static boolean visit[]; //연결여부 탐색할 때 사용했는지 여부 확인용
+	static List<Integer> red = new LinkedList<>(); //파란선거구
+	static List<Integer> blue = new LinkedList<>(); //빨간선거구
+	static int ans = Integer.MAX_VALUE;
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		pop = new int[N+1];
+		select = new boolean[N+1];
+		m = new boolean[N+1][N+1];
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		for(int i=1; i<=N; i++)pop[i] = Integer.parseInt(st.nextToken());
+		
+		//입력
+		for(int i=1; i<=N; i++) {
+			st = new StringTokenizer(br.readLine());
+			int C = Integer.parseInt(st.nextToken());
+			
+			for(int j=0; j<C; j++) {
+				int adj = Integer.parseInt(st.nextToken());
+				m[i][adj] = true;
+				m[adj][i] = true;
+			}
+		}
+		
+		partial(0);
+		if(ans == Integer.MAX_VALUE) System.out.println("-1");
+		else System.out.println(ans);
+	}
+	
+	static void partial(int cnt) {
+		if(cnt == N) { //선거구를 다 뽑았으면
+			visit = new boolean[N+1];
+			red = new LinkedList<>();
+			blue = new LinkedList<>();
+
+			//선택된 수는 레드로, 그 외에는 블루로 넣음
+			for(int i=1; i<=N; i++) {
+				if(select[i]) red.add(i);
+				else blue.add(i);
+			}
+			int rsize = red.size();
+			int bsize = blue.size();
+			
+			if(rsize == 0 || bsize == 0) return;
+			
+			//지역 선거구 연결여부 확인
+			dfs(red.get(0), 'r');
+			for(int i=0; i<rsize; i++) if(!visit[red.get(i)]) return;
+			
+			dfs(blue.get(0), 'b');
+			for(int i=0; i<bsize; i++) if(!visit[blue.get(i)]) return;
+			
+			//인구수 총합 구함
+			int rsum = 0;
+			int bsum = 0;
+			for(int i=0; i<rsize; i++) rsum += pop[red.get(i)];
+			for(int i=0; i<bsize; i++) bsum += pop[blue.get(i)];
+			
+			//각각의 인구 합 구하고 비교
+			ans = Math.min(ans,  Math.abs(rsum-bsum));
+			return;
+		}
+		
+		select[cnt]=true;
+		partial(cnt+1);
+		select[cnt]=false;
+		partial(cnt+1);
+	}
+	
+	//type에 해당하는 선거구에 포함되는지 확인
+	static void dfs(int idx, char type) {
+		visit[idx] = true;
+		
+		for(int i=1; i<=N; i++) {
+			if(type == 'r' && m[idx][i] && red.contains(i) && !visit[i]) dfs(i, type);
+			if(type == 'b' && m[idx][i] && blue.contains(i) && !visit[i]) dfs(i, type);
+		}
+	}
+}


### PR DESCRIPTION
### 게리맨더링
- 선거구를 뽑는 방식을 결국엔 1개에서부터 N-1개 뽑는 경우까지 모두 필요하기 때문에 부분집합으로 접근해야겠다고 생각했습니다.
- 부분집합으로 뽑은 수들과 안 뽑은 수로 선거구를 2개로 분리하고 각각에 대해서 연결여부를 확인하도록 접근합니다.
- 연결여부 확인은 링크드리스트로써 선거구에 포함된 지역들을 관리했고, dfs를 통해서 **연결이 되어있으면서, 방문하지 않았고, 현재 선거구에 포함된 지역**만 담도록 해서 방문체크 해줍니다.
- 연결되어있는지가 확인되면 인구수만큼 합을 구하고 정답을 갱신해줍니다.

### 연구소2
- 바이러스가 배치될 수 있는 좌표들에 대해서 모든 경우를 탐색해야 하고, 순서는 상관이 없기 때문에 조합으로 접근했습니다.
- 조합의 결과로 선택된 좌표에서 시작하는 bfs를 호출해서 맵에서 소요시간을 지정해주었습니다. 이때 유효성 검사에서 이미 갔던 좌표라도 **더 빠르게 갈 수 있는 방법이 있을 수 있기 때문에** 현재까지 소요시간 +1 보다 더 큰지 작은지를 추가로 확인해주어야 했습니다.
- 모든 bfs 탐색이 끝나고 맵 전체를 돌아보면서 아직 빈 칸이 있으면 그냥 종료시키고, 모든 빈칸이 채워지면 소요시간 중 가장 큰 값을 리턴합니다. 그리고 이 값이 0과 같거나 클 때만 정답을 갱신해줬어요. (0을 포함시키지 않으면 바이러스 외에 모든 칸이 벽인 경우를 통과 못함)