### PR TITLE
0412 육다빈 - 게리멘더링, 연구소2

### DIFF
--- a/육다빈/0412/b17141.java
+++ b/육다빈/0412/b17141.java
@@ -1,0 +1,90 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class G17141_lab2 {
+	static int N, M, size, space=0, result=Integer.MAX_VALUE;
+	static int[][] map;
+	static int[] list;
+	static List<Node> virus = new ArrayList<>();
+	static int[] di = {-1, 0, 1, 0};
+	static int[] dj = {0, 1, 0, -1};
+	static class Node{
+		int i, j;
+		Node(int i, int j){
+			this.i = i;
+			this.j = j;
+		}
+	}
+	static void comb(int n, int start) {
+		if(n==M) {
+			spread();
+			return;
+		}
+		for(int i=start; i<size; i++) {
+			list[n] = i;
+			comb(n+1, i+1);
+		}
+	}
+	static void spread() {
+		Queue<Node> queue = new LinkedList<>();
+		boolean[][] visit = new boolean[N][N];
+		for(int i : list) {
+			Node now = virus.get(i);
+			queue.add(now);
+			visit[now.i][now.j] = true;
+		}
+		int time = 0;
+		int cnt = M;
+		while(!queue.isEmpty()) {
+			int size = queue.size();
+			for(int q=0; q<size; q++) {
+				Node now = queue.poll();
+				for(int d=0; d<4; d++) {
+					int ni = now.i + di[d];
+					int nj = now.j + dj[d];
+					if(ni<0 || ni>=N || nj<0 || nj>=N || map[ni][nj]==1 || visit[ni][nj]) continue;
+					cnt++;
+					visit[ni][nj] = true;
+					queue.add(new Node(ni, nj));
+				}
+			}
+			if(++time>=result) return;
+			if(cnt==space) break;
+		}
+		if(cnt==space) result = time;
+	}
+  
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		map = new int[N][N];
+		list = new int[M];
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j=0; j<N; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				if(map[i][j]==2) virus.add(new Node(i, j));
+				if(map[i][j]!=1) space++;
+			}
+		}
+		if(space==M) {
+			System.out.println(0);
+			return;
+		}
+		size = virus.size();
+		comb(0, 0);
+		System.out.println((result==Integer.MAX_VALUE)?-1:result);
+	}
+
+}

--- a/육다빈/0412/b17471.java
+++ b/육다빈/0412/b17471.java
@@ -1,0 +1,84 @@
+package gold;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class G17471_gerryMandering {
+
+	static int N, result = Integer.MAX_VALUE;
+	static int[] visit, gu;
+	static List<Integer>[] linkedGu;
+	static List<Integer> setA, setB;
+	
+	static void subset(int n) {
+		if(n>N) {
+			setA = new ArrayList<>();
+			setB = new ArrayList<>();
+			for(int i=1; i<=N; i++) {
+				if(visit[i]==1) setA.add(i);
+				else setB.add(i);
+			}
+			if(setA.size()==0 || setB.size()==0 || 
+					countLinkedGu(setA, 1) + countLinkedGu(setB, 2) != N) return;
+			int sumA = 0, sumB = 0;
+			for(int i=1; i<=N; i++) {
+				if(visit[i]==1) sumA += gu[i];
+				else sumB += gu[i];
+			}
+			result = Math.min(result, Math.abs(sumA-sumB));
+			return;
+		}
+		visit[n] = 1;
+		subset(n+1);
+		visit[n] = 2;
+		subset(n+1);
+	}
+	
+	static int countLinkedGu(List<Integer> set, int n) {
+		int cnt = 1;
+		Queue<Integer> queue = new LinkedList<Integer>();
+		queue.add(set.get(0));
+		while(!queue.isEmpty()) {
+			int now = queue.poll();
+			set.remove((Object)now);
+			for(int li : linkedGu[now]) {
+				if(set.contains(li)) {
+					set.remove((Object)li);
+					cnt++;
+					queue.add(li);
+				}
+			}
+		}
+		return cnt;
+	}
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		N = Integer.parseInt(br.readLine());
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		gu = new int[N+1];
+		visit = new int[N+1];
+		for(int i=1; i<=N; i++) gu[i] = Integer.parseInt(st.nextToken());
+		
+		linkedGu = new ArrayList[N+1];
+		for(int i=1; i<=N; i++) {
+			linkedGu[i] = new ArrayList<>();
+			st = new StringTokenizer(br.readLine());
+			int len = Integer.parseInt(st.nextToken());
+			for(int j=0; j<len; j++) {
+				linkedGu[i].add(Integer.parseInt(st.nextToken()));
+			}
+		}
+		subset(1);
+		System.out.println(result==Integer.MAX_VALUE ? -1 : result);
+	}
+
+}


### PR DESCRIPTION
# 게리멘더링
- 사용 알고리즘 : 부분조합 & BFS
전체 노드에 대해 부분조합으로 나눌 수 있는 모든 경우의 선거구를 구한 뒤,
나눠진 구역이 모두 연결되어 있는 경우들에 대하여 인구 수 차이의 최솟값을 구했습니다.

# 연구소2
- 사용 알고리즘 : 조합 & BFS
바이러스가 들어갈 수 있는 자리들 중 M가지를 조합으로 선택한 뒤, 선택한 위치를 queue에 넣어 bfs로 계산하였습니다.