### PR TITLE
0422 한윤석 벽 부수고 이동하기

### DIFF
--- a/한윤석/0415/b17070_파이프옮기기1_revenge.java
+++ b/한윤석/0415/b17070_파이프옮기기1_revenge.java
@@ -1,0 +1,45 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class B17070_파이프옮기기1_2 {
+
+	static int N;
+	static int m[][];
+	static int dp[][][];
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		m = new int[N][N];
+		dp = new int[N][N][3];
+		
+		for(int i=0; i<N; i++) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			for(int j=0; j<N; j++) m[i][j] = Integer.parseInt(st.nextToken());
+		}
+		
+		dp[0][1][2] = 1;
+		for(int i=0; i<N; i++) {
+			for(int j=2; j<N; j++) {
+				if(m[i][j] == 1) continue;
+				
+				dp[i][j][2] += dp[i][j-1][2] + dp[i][j-1][1];
+				if(i>0) {
+					dp[i][j][0] += dp[i-1][j][0] + dp[i-1][j][1];
+					
+					if(m[i-1][j] == 1 || m[i][j-1] == 1 || m[i-1][j-1] == 1) continue;
+					
+					dp[i][j][1] += dp[i-1][j-1][0] + dp[i-1][j-1][1] + dp[i-1][j-1][2];
+				}
+			}
+		}
+		
+		System.out.println(dp[N-1][N-1][0] + dp[N-1][N-1][1] + dp[N-1][N-1][2]);
+	}
+}

--- a/한윤석/0422/b2206.java
+++ b/한윤석/0422/b2206.java
@@ -1,0 +1,74 @@
+public class B2206_벽부수고이동하기 {
+
+	static int R,C; //행, 열
+	static char m[][]; //맵 정보
+	static int memo[][][]; //행, 열, 벽 부쉈는지 여부(0 = 안부숨)
+	static int d[][] = {{1,0},{-1,0},{0,1},{0,-1}};
+	static int ans = Integer.MAX_VALUE;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		Queue<int []> q = new LinkedList<>();
+		R = Integer.parseInt(st.nextToken());
+		C = Integer.parseInt(st.nextToken());
+		m = new char[R][C];
+		memo = new int[R][C][2];
+		
+		for(int i=0; i<R; i++) {
+			m[i] = br.readLine().toCharArray();
+			for(int j=0; j<C; j++) {
+				memo[i][j][0] = Integer.MAX_VALUE;
+				memo[i][j][1] = Integer.MAX_VALUE;
+			}
+		}
+		
+		memo[0][0][0] = 1;
+		memo[0][0][1] = 1;
+		bfs();
+
+		if(ans == Integer.MAX_VALUE) System.out.println("-1");
+		else System.out.println(ans);
+	}
+	
+	static void bfs() {
+		Queue<int []> q = new LinkedList<>();
+		q.add(new int[] {0,0,0}); //행, 열, 부수기 사용 여부
+		
+		while(!q.isEmpty()) {
+			int [] p = q.poll();
+
+			//목적지 도달했으면
+			if(p[0] == R-1 && p[1] == C-1) {
+				ans = Math.min(memo[p[0]][p[1]][p[2]], ans);
+				continue;
+			}
+			
+			for(int i=0; i<4; i++) {
+				int nr = p[0] + d[i][0];
+				int nc = p[1] + d[i][1];
+				
+				if(!isValid(p, nr, nc)) continue;
+				
+				if(m[nr][nc] == '0') { //갈 수 있는 칸이면 자기 자신의 부순 여부 상태 그대로 갱신
+					q.add(new int[] {nr, nc, p[2]});
+					memo[nr][nc][p[2]] = Math.min(memo[nr][nc][p[2]], memo[p[0]][p[1]][p[2]]+1);
+				}
+				//부순 적 없는데 벽 만났으면, 부쉈다고 체크하고 부순 상태의 memo로 갱신
+				else if(p[2] == 0 && m[nr][nc] == '1') { 
+					q.add(new int[] {nr, nc, 1});
+					memo[nr][nc][1] = Math.min(memo[nr][nc][1], memo[p[0]][p[1]][0]+1);
+				}
+				
+			}
+		}
+	}
+	
+	static boolean isValid(int [] p, int nr, int nc) {
+		if(nr < 0 || nc < 0 || nr >= R || nc >= C) return false; //범위 검사
+		if(memo[nr][nc][p[2]] <= memo[p[0]][p[1]][p[2]]+1) return false; //최소 걸음 검사
+		if(p[2] == 1 && m[nr][nc] == '1') return false; //이미 벽 부순 적 있는데 또 벽일 때 검사
+		
+		return true;
+	}
+}


### PR DESCRIPTION
### 벽 부수고 이동하기
- 처음엔 단순한 메모이제이션과 BFS를 결합한 문제라고 생각해서 접근했는데 실패했음. 이유를 파악해보니 벽을 안뚫고 갈 수 있는 자리인데 이미 벽을 뚫고 먼저 방문하고 그 자리의 memo를 갱신해버려서 벽을 안 뚫고 해당 칸을 방문했을 때 유효성 검사에서 걸리는 문제가 발생했음. 따라서 [i,j]를 방문했을 때 해당 칸이 벽을 부순 적 있는지에 따라 갱신되어야 할 값이 달라져야 했음.
- 3차원으로 접근해야겠다고 생각했고 [말이 되고픈 원숭이](https://www.acmicpc.net/problem/1600) 문제처럼 접근을 비슷하게 하면 될 것 같다고 판단했음.

- bfs를 돌면서 내가 벽을 부순 적 없으면 부쉈다는 것을 체크해주고,부수지 않았을 때 현재까지의 걸음수+1로 갱신해주었음. 원래 갈 수 있는 칸이면 자기 자신의 상태에 따라 갱신해줌

### 지난 번 스터디 문제 파이프 부수기1 풀었어요