### PR TITLE
0422 / 2631 - 줄세우기, 2206 - 벽 부수고 이동하기

### DIFF
--- a/우상욱/p_2206.java
+++ b/우상욱/p_2206.java
@@ -1,0 +1,87 @@
+package bj;
+
+import java.io.*;
+import java.util.*;
+
+public class p_2206 {
+
+	static int[][] map, visited, wall_visited;
+	static int dx[] = { 0, 0, 1, -1 };
+	static int dy[] = { 1, -1, 0, 0 };
+	static int N, M;
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		// input map
+		map = new int[N][M];
+		for (int i = 0; i < N; i++) {
+			String ip = br.readLine();
+			for (int j = 0; j < M; j++) {
+				map[i][j] = ip.charAt(j) - '0';
+			}
+		}
+
+		// BFS
+		visited = new int[N][M]; // 2: not use drill, 1: use drill, 0: not visited
+		
+		Queue<Point> q = new LinkedList<>();
+		visited[0][0] = 2;
+		q.add(new Point(0, 0, 0, false));
+
+		while (!q.isEmpty()) {
+			Point p = q.poll();
+			if (p.x == N - 1 && p.y == M - 1) {
+				System.out.println(p.cost + 1);
+				return;
+			}
+
+			// destination
+			for (int d = 0; d < 4; d++) {
+				int nx = p.x + dx[d];
+				int ny = p.y + dy[d];
+
+				if (nx < 0 || nx >= N || ny < 0 || ny >= M)
+					continue;
+				// already break wall
+				if (map[nx][ny] == 1 && p.isBreak)
+					continue;
+				// not yet
+				if (map[nx][ny] == 1 && !p.isBreak) {
+					visited[nx][ny] = 1;
+					q.add(new Point(nx, ny, p.cost + 1, true));
+					continue;
+				}
+
+				// visited
+				if (visited[nx][ny] == 2)
+					continue;
+				if(visited[nx][ny] == 1 && p.isBreak)
+					continue;
+
+				if(p.isBreak)
+					visited[nx][ny] = 1;
+				else
+					visited[nx][ny] = 2;
+				q.add(new Point(nx, ny, p.cost + 1, p.isBreak));
+			}
+		}
+
+		System.out.println(-1);
+	}
+
+	static class Point {
+		int x, y, cost;
+		boolean isBreak;
+
+		Point(int x, int y, int cost, boolean isBreak) {
+			this.x = x;
+			this.y = y;
+			this.cost = cost;
+			this.isBreak = isBreak;
+		}
+	}
+}

--- a/우상욱/p_2631.java
+++ b/우상욱/p_2631.java
@@ -1,0 +1,35 @@
+package bj;
+
+import java.util.*;
+import java.io.*;
+
+public class p_2631 {
+
+	static int[] nums, dp;
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		
+		// number input
+		nums = new int[N];
+		for(int i = 0; i < N; i++)
+			nums[i] = Integer.parseInt(br.readLine());
+		
+		dp = new int[N];
+		Arrays.fill(dp, 1);
+		
+		int ans = 1;
+		for(int i = 1; i < N; i++) {
+			for(int j = 0; j < i; j++) {
+				if(nums[i] > nums[j]) {
+					dp[i] = Math.max(dp[i], dp[j] + 1);
+				}
+			}
+			ans = Math.max(ans, dp[i]);
+		}
+		
+		System.out.println(N - ans);
+	}
+	
+}


### PR DESCRIPTION
두문제 다 아이디어성이 짙은 문제, 그래서... 설명할게 많다

2631. 줄세우기
입력, 3 7 5 2 6 1 4 에서
... 3 ... 5 ... 6 ... 이렇게가 가장 긴 중가하는 부분 수열
이렇게 3개의 숫자를 움직이지 않고 고정시킨다고 생각 했을때,
나머지 7, 2, 1, 4 숫자들을 그냥 나머지 공간에 넣는다고 생각 하면 된다. 이것이 최소이동

이제 문제는 가장 긴 증가하는 부분 수열 문제가 되었다 ㅎㅎ DP ㄱㄱ

2206. 벽 부수고 이동하기
N, M이 1000이 넘어가기 때문에 일단 DFS는 아웃
이동한 거리를 Map 등에다가 저장하고 비교하면서 가지치기 하는 것(다익스트라 알고리즘 접근 방법)으로는 BFS에서 메모리초과

좀 더 그리디하게 접근하면 BFS는 걍 먼저 도착하면 거리고 뭐고 그것이 최단 거리
문제는 벽을 부수는 게 있다는 건데...

여기서 visited 배열의 접근을 조금 다르게 해야한다.
벽을 부수고 도착한 장소에 벽을 안부수고 도착한 경우의 수가 있다면
벽을 안부수고 온 경우가 무조건 이득이기 때문에, 이미 지나갔더라도 그곳을 지나갈 수 있어야 한다
(나중에 벽을 부숴서 얻을 수 있는 이득이 이미 벽을 부숴서 얻은 이득보다 클 수 있기 때문에)

결론은
- 벽을 부수고 온 녀석      :  누가 지나갔든간에 이미 지나갔으면 못지니감
- 벽을 안부수고 온 녀석  : 안부수고 온 녀석이 지나간건 못지나가고,  벽부수고 온 놈만 지나갔으면 지나갈 수 있음