### PR TITLE
0513 / 18430 - 무기 공학, 전력망을 둘로 나누기

### DIFF
--- a/우상욱/p_18430.java
+++ b/우상욱/p_18430.java
@@ -1,0 +1,73 @@
+package bj;
+
+import java.io.*;
+import java.util.*;
+
+public class p_18430 {
+
+	static int N, M, ans;
+	static int[][] wood;
+	
+	static int[] dx = {-1, 0, 1, 0};
+	static int[] dy = {0, 1, 0, -1};
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		
+		// input wood strength
+		wood = new int[N][M];
+		for(int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for(int j = 0; j < M; j++) {
+				wood[i][j] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		ans = 0;
+		makeBoom(0, 0, 0);
+		
+		System.out.println(ans);
+	}
+	
+	static void makeBoom(int cnt, int sum, int visited) {
+		if(cnt == N * M) {
+			ans = Math.max(ans, sum);
+			return;
+		}
+		int x = cnt / M;
+		int y = cnt % M;
+		
+		for(int d = 0; d < 4; d++) {
+			if((visited & 1 << cnt) == 1 << cnt)
+				break;
+			int nx1 = x + dx[d], ny1 = y + dy[d];
+			int nx2 = x + dx[(d + 1) % 4], ny2 = y + dy[(d + 1) % 4];
+			
+			// bound check
+			if(nx1 < 0 || ny1 < 0 || nx1 >= N || ny1 >= M)
+				continue;
+			if(nx2 < 0 || ny2 < 0 || nx2 >= N || ny2 >= M)
+				continue;
+			
+			// visited check
+			int pos = nx1 * M + ny1;
+			if((visited & 1 << pos) == 1 << pos)
+				continue;
+			pos = nx2 * M + ny2;
+			if((visited & 1 << pos) == 1 << pos)
+				continue;
+			
+			// visit
+			int next_v = visited | 1 << (nx1 * M + ny1);
+			next_v |= 1 << (nx2 * M + ny2);
+			next_v |= 1 << cnt;
+				
+			makeBoom(cnt + 1, sum + wood[nx1][ny1] + wood[nx2][ny2] + wood[x][y] * 2, next_v);
+		}
+		
+		makeBoom(cnt + 1, sum, visited);
+	}
+}

--- a/우상욱/p_86971.java
+++ b/우상욱/p_86971.java
@@ -1,0 +1,77 @@
+package programmers;
+
+import java.util.*;
+
+public class p_86971 {
+	public static void main(String[] args) {
+		new Solution().solution(4, new int[][] {{1,2},{2,3},{3,4}});
+	}
+	
+	// 전력망을 둘로 나누기
+	static class Solution {
+		ArrayList<ArrayList<Node>> graph;
+		
+		public int solution(int n, int[][] wires) {
+	    	// make graph
+	    	graph = new ArrayList<>();
+	    	for(int i = 0; i <= n; i++)
+	    		graph.add(new ArrayList<>());
+	    	
+	    	// input edges
+	    	for(int i = 0; i < wires.length; i++) {
+	    		int from = wires[i][0];
+	    		int to = wires[i][1];
+	    		
+	    		graph.get(from).add(new Node(from, to));
+	    		graph.get(to).add(new Node(to, from));
+	    	}
+	    	
+	    	// get answer
+	    	int answer = Integer.MAX_VALUE;
+	    	for(int i = 0; i < wires.length; i++)
+	    		answer = Math.min(answer, Math.abs(n - 2 * getNodeEA(wires[i][0], wires[i][1])));
+	        return answer;
+	    }
+	    
+	    
+		public int getNodeEA(int from, int to) {
+	    	int ret = 1;
+	    	// BFS
+	    	Queue<Node> q = new LinkedList<>();
+	    	boolean visited[] = new boolean[graph.size()];
+	    	visited[from] = true;
+	    	
+	    	for(int i = 0; i < graph.get(from).size(); i++) {
+	    		Node next = graph.get(from).get(i);
+	    		
+	    		if(next.to == to)
+	    			continue;
+	    		visited[next.to] = true;
+	    		q.add(next);
+	    	}
+	    	
+	    	while(!q.isEmpty()) {
+	    		Node n = q.poll();
+	    		ret++;
+	    		
+	    		for(int i = 0; i < graph.get(n.to).size(); i++) {
+	    			Node next = graph.get(n.to).get(i);
+	    			
+	    			if(!visited[next.to]) {
+	    				visited[next.to] = true;
+	    				q.add(next);
+	    			}
+	    		}
+	    	}
+	    	return ret;
+	    }
+	    
+		class Node {
+	    	int from, to;
+	    	public Node(int from, int to) {
+	    		this.from = from;
+	    		this.to = to;
+	    	}
+	    }
+	}
+}


### PR DESCRIPTION
18430. 무기 공학
Brute Force 완탐 문제,
얼마나 더 깔끔하게 구현하냐가 관건

전력망을 둘로 나누기
입력이 모두 연결된 트리형태로 주어진다 했기 때문에
어느 부분의 간선을 자르든 2개의 트리로 나누어 지게 된다.

간선 별루 하나씩 잘라보고 잘린 쪽의 양쪽 노드 중 아무데서나
탐색해서 노드의 갯수를 세면 된다.