### PR TITLE
0614 조윤혁 트리의 지름, 파일명 정렬 2문제

### DIFF
--- a/조윤혁/0614/b1967_트리의지름.java
+++ b/조윤혁/0614/b1967_트리의지름.java
@@ -1,0 +1,79 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int N, lastNode, resultSum;
+	static List<Node> list[];
+	static boolean[] visited;
+	
+    public static void main(String[] args) throws IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    	StringTokenizer st;
+    	
+    	N = parse(br.readLine());
+    	list = new ArrayList[N+1];
+    	visited = new boolean[N+1];
+    	
+    	for(int i=0; i<N+1; i++) {
+    		list[i] = new ArrayList<>();
+    	}
+    	
+    	for(int i=0; i<N-1; i++) {
+    		st = new StringTokenizer(br.readLine());
+    		int parent = parse(st.nextToken());
+    		int child = parse(st.nextToken());
+    		int cost = parse(st.nextToken());
+    		list[parent].add(new Node(child, cost));
+    		list[child].add(new Node(parent, cost));
+    	}
+    	
+//    	for(int i=1; i<=N; i++) {
+//    		for(Node node : list[i])
+//    			System.out.print ("[" +node.v + " : " + node.cost+"]");
+//    		System.out.println();
+//    	}
+    	
+    	visited[1] = true; // 어떤 노드가 들어와도 된다.
+    	dfs(1, 0); // lastNode를 구하기 위함, 어떤 노드가 들어가도 최대의 가중치의 끝 노드를 찾게 됨
+    	
+    	visited = new boolean[N+1]; // 초기화
+    	resultSum = 0; // 두점사이 누적된 가중치
+    	visited[lastNode] = true; 
+    	dfs(lastNode, 0); // lastNode에서 최대의 가중치의 끝 노드 찾기
+    	
+    	System.out.println(resultSum);
+    	
+    }
+    
+    
+	private static void dfs(int currV, int costSum) {
+		if(resultSum < costSum) {
+			resultSum = costSum;
+			lastNode = currV;
+		}
+		
+		for(Node nextV : list[currV]) {
+			if(visited[nextV.v]) continue;
+			visited[nextV.v] = true;
+			dfs(nextV.v, costSum + nextV.cost);
+		}
+	}
+
+
+	private static int parse(String str) {
+		return Integer.parseInt(str);
+	}
+    
+	private static class Node{
+		int v, cost;
+		Node(int v, int cost){
+			this.v = v;
+			this.cost = cost;
+		}
+	}
+    
+}

--- a/조윤혁/0614/p파일명정렬.java
+++ b/조윤혁/0614/p파일명정렬.java
@@ -1,0 +1,35 @@
+import java.util.Arrays;
+
+class Solution {
+    public String[] solution(String[] files) {
+        
+        Arrays.sort(files, (o1, o2) -> {
+            String headA = o1.split("[0-9]")[0].toUpperCase(); // number앞까지 자르기, 문자열 비교 시 대소문자 구분을 하지 않음
+            String headB = o2.split("[0-9]")[0].toUpperCase(); 
+            
+            if(headA.compareTo(headB) == 0){ // 파일명의 HEAD 부분이 대소문자 차이 외에는 같을 경우, NUMBER의 숫자 순으로 정렬
+                String numberA = o1.substring(headA.length());
+                String numberB = o2.substring(headB.length());
+                
+                // 숫자끼리 비교해야 함
+                return Integer.parseInt(splitNum(numberA)) - Integer.parseInt(splitNum(numberB));
+            }else{
+                return headA.compareTo(headB);
+            }
+        });
+        
+        return files;
+    }
+    
+    private static String splitNum(String num) { //최대 5자리인 number 계산
+        StringBuilder sb = new StringBuilder(); // number+Tail 형태에서 number만을 담아주기 위해 선언
+        for (char ch : num.toCharArray()) {
+            if (Character.isDigit(ch) && sb.length() <= 5) {//숫자이고 다섯글자 이하
+                sb.append(ch);
+            } else {
+                return sb.toString();
+            }
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
- 트리의 지름
dfs를 두번 돌립니다. 처음 돌릴때는 임의로 정한 노드를 지정해서 가장 가중치가 큰 끝 노드를 찾습니다. 두번째 dfs를 돌릴때는 처음 dfs를 통해 찾은 끝 노드로 다시 돌려주면 됩니다.  

- 파일명 정렬
comparater를 구현해서 풀었습니다. 비교시 대소문자 신경을 안쓰는점, head와 number를 split해주는 부분이 중요했던 것 같습니다. 


한달만에 문제를 푸려니 너무 어렵네요..ㅎ 심지어 오래전에 봤었던 문제들인데도..블로그 참고 많이했습니다ㅠ 다음에는 다풀어오겠습니다..!