### PR TITLE
0628 / 2229 - 조 짜기

### DIFF
--- a/우상욱/p_2229.java
+++ b/우상욱/p_2229.java
@@ -1,0 +1,34 @@
+package bj;
+
+import java.io.*;
+import java.util.*;
+
+public class p_2229 {
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		// input scores
+		int scores[] = new int[N + 1];
+		for (int i = 1; i <= N; i++)
+			scores[i] = Integer.parseInt(st.nextToken());
+
+		// max score until i index
+		int dp[] = new int[N + 1];
+		dp[0] = 0;
+
+		int min, max;
+		for (int i = 1; i <= N; i++) {
+			max = min = scores[i];
+
+			for (int j = i; j >= 1; j--) {
+				max = Math.max(max, scores[j]);
+				min = Math.min(min, scores[j]);
+				dp[i] = Math.max(dp[i], max - min + dp[j - 1]);
+			}
+		}
+
+		System.out.println(dp[N]);
+	}
+}


### PR DESCRIPTION
2229. 조 짜기

일단 문제 이해하기가 어려운데 그냥 나누는 거라고 생각하면 된다
조는 무조건 연속적이여야 함
하지만 칸막이를 넣는다고 생각하고 풀면 N이 1000이라 무조건 시간초과

일단 DP로 푸는건 알겠고...
N번째 까지 조를 짰을 때의 최대값을 dp[N] 이라 놓는것 까진 OK
+ 2중 for 문으로 구해야 하는 것까진 OK

EX) dp[3] 까지 구한 상태에서 dp[4]를 구할때
Max ( dp[3] + (4 - 4번 점수 최대 최소 차), dp[2] + (3 - 4 ... ), dp[1] + (2 - 4 ... ), dp[0] + (1 - 4 ...) )
dp[0] = 0으로 설정

근데 문제가 최대 최소를 구하는거... ;;
for 문 하나 더 돌리면 시간 초과...

그래서 두번째 for 문을 증가가 아니라 감소로 구현
차례로 입력이 주어 진다 생각하면 된다.
이거 최적화 하는데 거의 4시간은 고민한듯

평균 구하기 같은거? 도 마찬가지로 응용 가능할듯