### PR TITLE
0705 회장뽑기 1문제

### DIFF
--- a/한윤석/0628/b2229_조짜기.java
+++ b/한윤석/0628/b2229_조짜기.java
@@ -1,0 +1,34 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class B2229_조짜기 {
+
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		int N = Integer.parseInt(br.readLine());
+		int arr [] = new int[N];
+		int dp [] = new int[N]; //0부터 i까지 고려했을 때 최대값
+		String [] input = br.readLine().split(" ");
+		
+		for(int i=0; i<N; i++) arr[i] = Integer.parseInt(input[i]);
+		
+		for(int i=0; i<N; i++) { //앞에서부터 탐색
+			int min = arr[i]; // j부터 i까지의 최소
+			int max = arr[i]; // j부터 i까지의 최대
+			
+			for(int j=i; j>=0; j--) { //i번부터 뒤로 탐색
+				min = Math.min(min, arr[j]);
+				max = Math.max(max, arr[j]);
+				
+				// j부터 i까지의 최대 차 + 직전까지의 합
+				if(j==0) dp[i] = Math.max(dp[i], max-min);
+				else dp[i] = Math.max(dp[i],  max - min + dp[j-1]); 
+			}
+		}
+		
+		System.out.println(dp[N-1]);
+	}
+}

--- a/한윤석/0628/p타겟넘버.java
+++ b/한윤석/0628/p타겟넘버.java
@@ -1,0 +1,29 @@
+package programmers;
+
+public class P타겟넘버 {
+
+	static int gnumbers [], gtarget, answer = 0;
+	public static void main(String[] args) {
+		int arr[] = {1,1,1,1,1};
+		int a = solution(arr, 3);
+		System.out.println(a);
+	}
+
+	static public int solution(int[] numbers, int target) {
+		gnumbers = numbers;
+		gtarget = target;
+		dfs(numbers[0], 1);
+		dfs(numbers[0] * -1, 1);
+        
+        return answer;
+    }
+	
+	static void dfs(int sum, int idx) {
+		if(idx == gnumbers.length) {
+			if(sum == gtarget) answer++;
+			return;
+		}
+		dfs(sum + gnumbers[idx], idx+1);
+		dfs(sum - gnumbers[idx], idx+1);
+	}
+}

--- a/한윤석/0704/b2660_회장뽑기.md
+++ b/한윤석/0704/b2660_회장뽑기.md
@@ -1,0 +1,129 @@
+### 전체코드 인접 배열 ver.
+```java
+public class Main {
+
+	static int N;
+	static boolean relation [][]; // [i] 후보자와 [j] 후보자가 연결되어있는지
+	static boolean visit[]; // i 방문했는지
+	static int minVal = Integer.MAX_VALUE; // 모든 관계가 형성되는데 소요된 최소 depth
+	static LinkedList<Integer> candidate = new LinkedList<>(); // 회장 후보자
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		relation = new boolean [N+1][N+1];
+		
+		while(true) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			
+			if(from == -1 || to == -1) break;
+			
+			relation[from][to] = true;
+			relation[to][from] = true;
+		}
+		
+		for(int i=1; i<=N; i++) {
+			visit = new boolean [N+1];
+			visit[i] = true;
+			bfs(i);
+		}
+
+		System.out.println(minVal + " " + candidate.size());
+		Collections.sort(candidate);
+		for(int i:candidate) System.out.print(i + " ");
+	}
+	
+	static void bfs(int start) {
+		Queue<int []> q = new LinkedList<>();
+		q.add(new int[] {start, 0}); //[0]node, [1]depth
+		int curDepth = 0;
+		
+		while(!q.isEmpty()) {
+			int [] info = q.poll();
+			
+			for(int i=1; i<=N; i++) {
+				if(visit[i] || !relation[info[0]][i]) continue;
+				
+				visit[i] = true;
+				q.add(new int[] {i, info[1]+1});
+				curDepth = Math.max(curDepth, info[1]+1);
+			}
+		}
+		
+		if(curDepth < minVal) {
+			minVal = curDepth;
+			candidate.clear();
+			candidate.add(start);
+		}else if(curDepth == minVal) candidate.add(start);
+	}
+	
+}
+```
+
+### 전체코드 인접 리스트 ver.
+```java
+public class B2660_회장뽑기 {
+
+	static int N;
+	static LinkedList<Integer> relation [];
+	static boolean visit[];
+	static int minVal = Integer.MAX_VALUE;
+	static LinkedList<Integer> candidate = new LinkedList<>();
+	
+	public static void main(String[] args) throws NumberFormatException, IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		N = Integer.parseInt(br.readLine());
+		relation = new LinkedList[N+1];
+		
+		for(int i=1; i<=N; i++) relation[i] = new LinkedList<>();
+		
+		while(true) {
+			StringTokenizer st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			
+			if(from == -1 || to == -1) break;
+			
+			relation[from].add(to);
+			relation[to].add(from);
+		}
+		
+		for(int i=1; i<=N; i++) {
+			visit = new boolean [N+1];
+			visit[i] = true;
+			bfs(i);
+		}
+
+		System.out.println(minVal + " " + candidate.size());
+		Collections.sort(candidate);
+		for(int i:candidate) System.out.print(i + " ");
+	}
+	
+	static void bfs(int start) {
+		Queue<int []> q = new LinkedList<>();
+		q.add(new int[] {start, 0}); //[0]node, [1]depth
+		int curDepth = 0;
+		
+		while(!q.isEmpty()) {
+			int [] info = q.poll();
+			
+			for(int i: relation[info[0]]) {
+				if(visit[i]) continue;
+				
+				visit[i] = true;
+				q.add(new int[] {i, info[1]+1});
+				curDepth = Math.max(curDepth, info[1]+1);
+			}
+		}
+		
+		if(curDepth < minVal) {
+			minVal = curDepth;
+			candidate.clear();
+			candidate.add(start);
+		}else if(curDepth == minVal) candidate.add(start);
+	}
+	
+}
+```


### PR DESCRIPTION
- 한 노드에서 다른 모든 노드를 방문하는데 필요한 depth의 최소와, 같은 최소값을 가지는 리스트를 구하는 문제.
- N의 범위가 50까지이고, 별도의 가중치가 존재하지 않기 때문에 2차원 배열을 선언하여 연결 여부를 확인하는 것으로 구현. 링크드 리스트로 구현해봤는데 애초에 범위가 작아서 그런지 메모리나 시간적인 측면에서 큰 메리트는 없어보였습니당
![image](https://user-images.githubusercontent.com/28249948/176992598-d3c8051e-f8e2-41f8-a04f-fe7da52b8948.png)
- 모든 노드를 for 루프를 돌아보면서 방문체크 배열을 초기화해주고, 각 노드들을 방문하면서 소요된 depth를 갱신해주는 것으로 솔브했어요