### PR TITLE
10/25 유창선(b2250 트리의 높이와 너비, b3079 입국심사)

### DIFF
--- a/유창선/1025/b2250_트리의높이와너비.java
+++ b/유창선/1025/b2250_트리의높이와너비.java
@@ -1,0 +1,79 @@
+package day1020;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class b2250_트리의높이와너비 {
+    static int N, visitedIndex = 1;
+    static ArrayList<ArrayList<Integer>> info = new ArrayList<>();
+    static int[][] visited;
+    static int[] parent;
+    static int root;
+    static int maxLevel = Integer.MIN_VALUE;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        visited = new int[N + 1][2];
+        parent = new int[N + 1];
+        for (int i = 1; i <= N; i++) parent[i] = i; // 부모 노드 찾기 초기화
+        for (int i = 0; i <= N; i++) {
+            info.add(new ArrayList<>());
+        }
+        for (int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int p = Integer.parseInt(st.nextToken());
+            int l = Integer.parseInt(st.nextToken());
+            int r = Integer.parseInt(st.nextToken());
+            info.get(p).add(l);
+            info.get(p).add(r);
+            if (l != -1) parent[l] = p;
+            if (r != -1) parent[r] = p;
+        } // end input
+        findRoot(1);
+        dfs(1, root);
+        getAns();
+    }
+
+    public static void getAns () {
+        int ansWidth = Integer.MIN_VALUE;
+        int ansLevel = -1;
+        for (int l = 1; l <= maxLevel; l++) {
+            int left = Integer.MAX_VALUE;
+            int right = Integer.MIN_VALUE;
+            for (int i = 1; i <= N; i++) {
+                if (visited[i][1] == l) { // 같은 레벨이라면
+                    left = Math.min(left, i); // 맨 왼쪽 구하기
+                    right = Math.max(right, i); // 맨 오른쪽 구하기
+                }
+            }
+            if (ansWidth < right - left) {
+                ansWidth = right - left;
+                ansLevel = l;
+            }
+        }
+        System.out.println(ansLevel + " " + (ansWidth + 1));
+
+    }
+
+    public static void dfs(int level, int parent) {
+        int left = info.get(parent).get(0);
+        int right = info.get(parent).get(1);
+        if (left != -1) dfs(level + 1, left); // 왼쪽
+        visited[visitedIndex][0] = parent;
+        visited[visitedIndex++][1] = level;
+        maxLevel = Math.max(level, maxLevel); // 최대 깊이 구해주기
+        if (right != -1) dfs(level + 1, right); // 오른쪽
+    }
+    public static void findRoot(int a) {
+        if (a == parent[a]) {
+            root = a;
+            return;
+        }
+        findRoot(parent[a]);
+
+    }
+}

--- a/유창선/1025/b3079_입국심사.java
+++ b/유창선/1025/b3079_입국심사.java
@@ -1,0 +1,44 @@
+package day1024;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class b3079_입국심사 {
+    static int N, M;
+    static long[] arr;
+    static long ans;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        arr = new long[N];
+        for (int i = 0; i < N; i++) {
+            arr[i] = Long.parseLong(br.readLine());
+        } // end input
+        long lt = 1;
+        long rt = Arrays.stream(arr).max().getAsLong() * M;
+
+        while (lt <= rt) {
+            long cnt = 0;
+            long time = (lt + rt) / 2;
+            boolean flag = false;
+            for (int i = 0; i < N; i++) {
+                cnt += (time) / arr[i];
+                if (cnt >= M) {
+                    flag = true;
+                    ans = time;
+                    break;
+                }
+            } // end for
+
+            if (flag) rt = time - 1;
+            else lt = time + 1;
+        }
+
+        System.out.println(ans);
+    }
+}


### PR DESCRIPTION
# 백준 2250 트리의 높이와 너비
- 주요 알고리즘 : dfs
- 풀이:
    - 크게 3가지 과정으로 나뉨
    1. 루트 노드 구하기
    2. 중위 순회를 돌며 위치 넣어주기
    3. 정답 구하기
##  1. 루트 노드 구하기
- `parent[]`를 사용하여 union & find에서 했던 것처럼 부모 노드를 구해줌
## 2. 중위 순회 돌며 위치 넣어주기
- `visited[][]` 2차원 배열을 선언하여 정보를 입력해준다.
    - `visited[i][0]` ->  i 번째 위치에 들어간 노드 번호
    - `visited[i][1]` -> 몇 번째 level (높이)에 들어 갔는지
    - 중위 순회이기 때문에 **왼쪽 -> 나 -> 오른쪽** 순으로 탐색
    - 정답 구할 때 사용하기 위해 `maxLevel` (최대 높이)를 구해준다.
## 3. 정답 구하기
- visited 2차원 배열에 높이 정보를 넣어줬기 때문에 높이가 같은 것들끼리 (**1 ~ maxLevel 까지**) 
- 맨 왼쪽 위치, 맨 오른쪽 위치를 구해서 뺀다. (너비 구하기)
- 너비가 최대라면 업데이트 

# 백준 3079 입국심사
- 주요 알고리즘 : 이분 탐색
- 풀이:
    - 가능한 시간을 이분 탐색한다. 
        - `lt = 1` , `rt = 가장 오래 걸리는 검색대 * 인원 수 (M)` 으로 초기화
        - `time = (lt + rt) / 2` 으로 시간 두고 해당 time 안에 검색대에서 M명 처리 가능한지 탐색
        - 각 검색대마다 time에 처리할 수 인원 수 더하기 `cnt += time / arr[i]`
        - 해당 시간안에 M 명 처리할 수 있으면 그 시간은 가능한 것!  `cnt >= M`
        - lt, rt 조정하기
        - 위 과정 반복